### PR TITLE
Do not force sticky notice when WP_DEBUG is true

### DIFF
--- a/src/Notifications/Notice.php
+++ b/src/Notifications/Notice.php
@@ -83,7 +83,7 @@ final class Notice
         $this->handle = sanitize_key($handle);
         $this->html = wp_kses_post($html);
         $this->type = sanitize_html_class($type ?? 'info');
-        $this->isSticky = $isSticky ?? (defined('WP_DEBUG') && true === WP_DEBUG);
+        $this->isSticky = $isSticky ?? false;
         $this->htmlClass = sanitize_html_class($htmlClass ?? 'sunny-admin-notice');
     }
 

--- a/src/Sunny.php
+++ b/src/Sunny.php
@@ -80,6 +80,7 @@ final class Sunny implements LoadableInterface
         $this->container->delegate(new ReflectionContainer);
         $this->container->add(OptionStore::class, $optionStore);
         $this->container->add(Admin::class, $admin);
+        $this->container->add(Notifier::class, null, true);
 
         $loadables = [
             __CLASS__,

--- a/tests/acceptance/Posts/Listener/PurgeWhenDraftPostPublishedCept.php
+++ b/tests/acceptance/Posts/Listener/PurgeWhenDraftPostPublishedCept.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use TypistTech\Sunny\FunctionalTester;
+use TypistTech\Sunny\AcceptanceTester;
 
-$I = new FunctionalTester($scenario);
+$I = new AcceptanceTester($scenario);
 $I->wantToTest('purge initiated when draft post published');
 
 $I->loginAsAdmin();

--- a/tests/acceptance/Posts/Listener/PurgeWhenNewPostPublishedCept.php
+++ b/tests/acceptance/Posts/Listener/PurgeWhenNewPostPublishedCept.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use TypistTech\Sunny\FunctionalTester;
+use TypistTech\Sunny\AcceptanceTester;
 
-$I = new FunctionalTester($scenario);
+$I = new AcceptanceTester($scenario);
 $I->wantToTest('purge initiated when new post published');
 
 $I->loginAsAdmin();

--- a/tests/acceptance/Posts/Listener/PurgeWhenPostUpdatedCept.php
+++ b/tests/acceptance/Posts/Listener/PurgeWhenPostUpdatedCept.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use TypistTech\Sunny\FunctionalTester;
+use TypistTech\Sunny\AcceptanceTester;
 
-$I = new FunctionalTester($scenario);
+$I = new AcceptanceTester($scenario);
 $I->wantToTest('purge initiated when post updated');
 
 $I->loginAsAdmin();


### PR DESCRIPTION
related: #84